### PR TITLE
Update Cpu.java

### DIFF
--- a/corewars8086/src/il/co/codeguru/corewars8086/cpu/Cpu.java
+++ b/corewars8086/src/il/co/codeguru/corewars8086/cpu/Cpu.java
@@ -662,11 +662,9 @@ public class Cpu {
                 callFar(newCS, newIP);
                 break;
             case (byte)0x9B: // original: WAIT, modified: virtual opcode NRG
-                // The virtual NRG opcode is made up of 4 consecutive WAIT opcodes
-                for (int i = 0; i < 3; ++i) {
-                    if (m_fetcher.nextByte() != (byte)0x9B) {
-                        throw new UnsupportedOpcodeException();
-                    }
+                // The virtual NRG opcode is made up of 2 consecutive WAIT opcodes
+                if (m_fetcher.nextByte() != (byte)0x9B) {
+                    throw new UnsupportedOpcodeException();
                 }
                 int energy = Unsigned.unsignedShort(m_state.getEnergy());
                 if (energy < 0xFFFF) {


### PR DESCRIPTION
The virtual NRG opcode now requires only 2 consecutive WAIT opcodes, as for the change made in 2017